### PR TITLE
Decrypt segments without calling encryption server

### DIFF
--- a/src/streaming/net/HTTPLoader.js
+++ b/src/streaming/net/HTTPLoader.js
@@ -225,7 +225,20 @@ function HTTPLoader(cfg) {
                 handleLoaded(true);
 
                 if (config.success) {
-                    config.success(httpRequest.response.response, httpRequest.response.statusText, httpRequest.response.responseURL);
+                    /**
+                     * Creates a map with all the response headers from the request
+                     */
+                    const headers = httpRequest.response.getAllResponseHeaders();
+                    const headersArray = headers.trim().split(/[\r\n]+/);
+                    const headersMap = {};
+                    headersArray.forEach(function (line) {
+                        const parts = line.split(': ');
+                        const header = parts.shift();
+                        const value = parts.join(': ');
+                        headersMap[header] = value;
+                    });
+
+                    config.success(httpRequest.response.response, httpRequest.response.statusText, httpRequest.response.responseURL, headersMap);
                 }
 
                 if (config.complete) {


### PR DESCRIPTION
- Now the HTTPLoader function returns the response headers on the success callback in order to have access to them from the decryption function
- The decryption process was updated to not send each segment to the backend